### PR TITLE
[codex] Incrementally merge touched movie data

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ Live crawler tests are opt-in:
 ENABLE_LIVE_CRAWLER_TESTS=true npm test
 ```
 
+Mongo integration tests use the local docker-compose MongoDB on port `27018`:
+
+```bash
+docker compose up -d mongodb
+npm run test:integration:mongo
+```
+
 MongoDB indexes: [doc/dbSetup.md](doc/dbSetup.md).
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
+        "tsx": "^4.22.4",
         "typescript": "^5.8.0",
         "vitest": "^2.0.0"
       },
@@ -577,6 +578,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -593,6 +610,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -607,6 +640,22 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -3284,6 +3333,433 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "build": "next build",
     "start": "next start",
     "db:indexes": "node scripts/createIndexes.js",
+    "db:merge": "tsx scripts/runMerge.ts",
     "db:rename-movie-bases": "node scripts/renameYahooMoviesCollection.js",
     "test": "vitest run",
+    "test:integration:mongo": "INTEGRATION_MONGO_URL=mongodb://localhost:27018/movierater_incremental_integration vitest run src/test/incrementalMerge.integration.test.ts",
     "test:watch": "vitest"
   },
   "private": true,
@@ -35,6 +37,7 @@
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "tsx": "^4.22.4",
     "typescript": "^5.8.0",
     "vitest": "^2.0.0"
   }

--- a/scripts/runMerge.ts
+++ b/scripts/runMerge.ts
@@ -1,0 +1,17 @@
+import { Mongo } from '../src/data/db';
+import { runMerge } from '../src/task/mergeTask';
+
+async function main() {
+  await Mongo.openDbConnection();
+  const merged = await runMerge();
+  console.log(`scripts/runMerge: merged ${merged.length} movies`);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    Mongo.closeDbConnection();
+  });

--- a/src/app/api/tasks/line/route.ts
+++ b/src/app/api/tasks/line/route.ts
@@ -4,6 +4,7 @@ import { updateLINEMovies } from '@/task/lineTask';
 import cacheManager from '@/data/cacheManager';
 import { updateLineSchedules } from '@/task/lineScheduleTask';
 import { updateComingSoonMovies } from '@/task/comingSoonTask';
+import { linkPttArticlesForMovieBases, runMergeForMovieBases } from '@/task/mergeTask';
 import { authorizeTaskRequest } from '../auth';
 
 export async function POST(request: Request) {
@@ -11,7 +12,10 @@ export async function POST(request: Request) {
   if (unauthorized) return unauthorized;
 
   try {
-    await updateLINEMovies();
+    const lineMovies = await updateLINEMovies();
+    const linkedPttArticles = await linkPttArticlesForMovieBases(lineMovies);
+    const mergedMovies = await runMergeForMovieBases(lineMovies);
+    await cacheManager.refreshMoviesCache();
     let comingSoonCount = 0;
     let comingSoonError: string | undefined;
     try {
@@ -29,9 +33,10 @@ export async function POST(request: Request) {
     // Bust ISR cache so individual theater pages show fresh data immediately.
     // /theaters itself is force-dynamic; CDN edge cache is handled via Cache-Control.
     revalidatePath('/theater/[name]', 'page');
+    revalidatePath('/');
     revalidatePath('/upcoming');
     revalidatePath('/sitemap.xml');
-    return NextResponse.json({ ok: true, scheduleCount: count, comingSoonCount, comingSoonError });
+    return NextResponse.json({ ok: true, scheduleCount: count, mergedCount: mergedMovies.length, linkedPttArticles, comingSoonCount, comingSoonError });
   } catch (err) {
     return NextResponse.json({ ok: false, error: String(err) }, { status: 500 });
   }

--- a/src/app/api/tasks/ptt/route.ts
+++ b/src/app/api/tasks/ptt/route.ts
@@ -1,10 +1,8 @@
 import { NextResponse } from 'next/server';
 import { revalidatePath } from 'next/cache';
-import { Mongo } from '@/data/db';
-import { COLLECTIONS } from '@/data/collections';
 import cacheManager from '@/data/cacheManager';
 import { updatePttArticles } from '@/task/pttTask';
-import Movie from '@/models/movie';
+import { runMergeForMovieBaseIds } from '@/task/mergeTask';
 import { authorizeTaskRequest } from '../auth';
 
 export async function POST(request: Request) {
@@ -12,28 +10,15 @@ export async function POST(request: Request) {
   if (unauthorized) return unauthorized;
 
   try {
-    // Ensure All_MOVIES cache is warm so findMovieBaseId can match article titles
-    if ((cacheManager.get(cacheManager.All_MOVIES) ?? []).length === 0) {
-      await cacheManager.refreshMoviesCache();
-    }
-    // Jump crawl index to near current PTT max so next runs pick up recent articles
-    await Mongo.updateDocument(
-      { name: 'crawlerStatus' },
-      { lastCrawlPttIndex: 10900 },
-      COLLECTIONS.configs
-    );
-    // Crawl articles + aggregate counts + persist to movieBases/mergedDatas
-    const pttCounts = await updatePttArticles(5);
-    // Patch in-memory caches immediately (same pattern as imdbTask)
-    const patchMap: Record<string, object> = {};
-    for (const c of pttCounts) {
-      patchMap[c._id] = { pttGoodCount: c.pttGoodCount, pttNormalCount: c.pttNormalCount, pttBadCount: c.pttBadCount };
-    }
-    const apply = (arr: Movie[]) => arr.map((m) => m.movieBaseId && patchMap[m.movieBaseId] ? { ...m, ...patchMap[m.movieBaseId] } : m);
-    cacheManager.set(cacheManager.All_MOVIES, apply(cacheManager.get(cacheManager.All_MOVIES) ?? []));
-    cacheManager.set(cacheManager.RECENT_MOVIES, apply(cacheManager.get(cacheManager.RECENT_MOVIES) ?? []));
+    // Crawl articles + aggregate counts only for touched movies.
+    const pttUpdate = await updatePttArticles(5);
+    const mergedMovies = await runMergeForMovieBaseIds(pttUpdate.movieBaseIds);
+    await cacheManager.refreshMoviesCache();
+    await cacheManager.setRecentMoviesCache();
+    revalidatePath('/');
+    revalidatePath('/movie/[id]', 'page');
     revalidatePath('/sitemap.xml');
-    return NextResponse.json({ ok: true, updatedMovies: pttCounts.length });
+    return NextResponse.json({ ok: true, articleCount: pttUpdate.articleCount, updatedMovies: pttUpdate.counts.length, mergedCount: mergedMovies.length });
   } catch (err) {
     return NextResponse.json({ ok: false, error: String(err) }, { status: 500 });
   }

--- a/src/crawler/pttCrawler.ts
+++ b/src/crawler/pttCrawler.ts
@@ -2,8 +2,7 @@ import * as cheerio from 'cheerio';
 import moment from 'moment';
 import Article from '../models/article';
 import PttPage from '../models/pttPage';
-import Movie from '../models/movie';
-import cacheManager from '../data/cacheManager';
+import MovieBase from '../models/movieBase';
 import isValideDate from '../helper/isValideDate';
 
 export async function getPttPage(index: number): Promise<PttPage> {
@@ -35,10 +34,9 @@ export async function getPttPage(index: number): Promise<PttPage> {
   };
 }
 
-export function findMovieBaseId(articleTitle: string, date: string): string | null {
-  const allMovies: Movie[] = cacheManager.get(cacheManager.All_MOVIES) ?? [];
+export function findMovieBaseId(articleTitle: string, date: string, movieBases: MovieBase[]): string | null {
   const articleDate = moment(date, 'YYYY/MM/DD');
-  const matched = allMovies.find((movie) => {
+  const matched = movieBases.find((movie) => {
     if (!movie.chineseTitle || movie.chineseTitle.length < 2) return false;
     if (!articleTitle.includes(movie.chineseTitle)) return false;
     const releaseDate = isValideDate(movie.releaseDate) ? moment(movie.releaseDate) : moment();
@@ -47,5 +45,5 @@ export function findMovieBaseId(articleTitle: string, date: string): string | nu
       releaseDate.clone().add(6, 'months')
     );
   });
-  return matched?.movieBaseId ?? null;
+  return matched?._id?.toHexString?.() ?? null;
 }

--- a/src/data/cacheManager.ts
+++ b/src/data/cacheManager.ts
@@ -26,10 +26,7 @@ export default class cacheManager {
   static THEATERS_BY_SCHEDULE_URL = 'theatersByScheduleUrl';
   static THEATERS_BY_LINE_THEATER_ID = 'theatersByLineTheaterId';
   static async init() {
-    const mergedDatas = await cacheManager.getMergedDatas();
-    cacheManager.set(cacheManager.All_MOVIES, mergedDatas);
-    cacheManager.setMovieLookupCache(mergedDatas);
-    cacheManager.setAllMoviesNamesCache(mergedDatas);
+    await cacheManager.refreshMoviesCache();
     await cacheManager.setTheatersCache();
     await cacheManager.setRecentMoviesCache();
     await cacheManager.setMoviesSchedulesCache();

--- a/src/task/lineTask.ts
+++ b/src/task/lineTask.ts
@@ -18,8 +18,15 @@ export async function updateLINEMovies() {
     },
     { concurrency: 10 }
   );
+  const lineMovieIds = movies.map((movie) => movie.lineMovieId).filter(Boolean);
+  const persistedMovies = lineMovieIds.length
+    ? await Mongo.db
+        .collection<MovieBase>(COLLECTIONS.movieBases)
+        .find({ lineMovieId: { $in: lineMovieIds } })
+        .toArray()
+    : [];
   console.log('Updated LINEMovies success.');
-  return movies;
+  return persistedMovies;
 }
 
 async function mapLineMovieToMovieBase(item: LINEMovieItem): Promise<MovieBase | null> {

--- a/src/task/mergeTask.ts
+++ b/src/task/mergeTask.ts
@@ -3,14 +3,81 @@ import { mergeData } from '../crawler/mergeData';
 import Article from '../models/article';
 import MovieBase from '../models/movieBase';
 import { COLLECTIONS } from '../data/collections';
+import { ObjectId } from 'mongodb';
+import moment from 'moment';
+import isValideDate from '../helper/isValideDate';
 
 export async function runMerge() {
   const [movieBases, pttArticles] = await Promise.all([
     Mongo.getCollection<MovieBase>({ name: COLLECTIONS.movieBases }),
     Mongo.getCollection<Article>({ name: COLLECTIONS.pttArticles, options: { projection: { _id: 0 } } }),
   ]);
+  return upsertMergedMovies(movieBases, pttArticles, 'runMerge');
+}
+
+export async function runMergeForMovieBases(movieBases: MovieBase[]) {
+  const movieBaseIds = movieBases.map((movie) => movie._id?.toHexString?.()).filter(Boolean);
+  return runMergeForMovieBaseIds(movieBaseIds);
+}
+
+export async function runMergeForMovieBaseIds(movieBaseIds: string[]) {
+  const uniqueIds = [...new Set(movieBaseIds.filter(Boolean))];
+  if (!uniqueIds.length) {
+    console.log('runMergeForMovieBaseIds: 0 movies');
+    return [];
+  }
+
+  const objectIds = uniqueIds
+    .filter((id) => ObjectId.isValid(id))
+    .map((id) => new ObjectId(id));
+  const [movieBases, pttArticles] = await Promise.all([
+    Mongo.db
+      .collection<MovieBase>(COLLECTIONS.movieBases)
+      .find({ _id: { $in: objectIds } } as any)
+      .toArray(),
+    Mongo.db
+      .collection<Article>(COLLECTIONS.pttArticles)
+      .find({ movieBaseId: { $in: uniqueIds } }, { projection: { _id: 0 } })
+      .toArray(),
+  ]);
+
+  return upsertMergedMovies(movieBases, pttArticles, 'runMergeForMovieBaseIds');
+}
+
+export async function linkPttArticlesForMovieBases(movieBases: MovieBase[]) {
+  let matchedArticles = 0;
+  for (const movie of movieBases) {
+    const movieBaseId = movie._id?.toHexString?.();
+    if (!movieBaseId || !movie.chineseTitle || movie.chineseTitle.length < 2) continue;
+
+    const releaseDate = isValideDate(movie.releaseDate) ? moment(movie.releaseDate) : moment();
+    const rangeStart = releaseDate.clone().subtract(3, 'months').format('YYYY/MM/DD');
+    const rangeEnd = releaseDate.clone().add(6, 'months').format('YYYY/MM/DD');
+    const result = await Mongo.db.collection(COLLECTIONS.pttArticles).updateMany(
+      {
+        title: { $regex: escapeRegExp(movie.chineseTitle) },
+        date: { $gte: rangeStart, $lte: rangeEnd },
+        $or: [
+          { movieBaseId: { $exists: false } },
+          { movieBaseId: null },
+          { movieBaseId: '' },
+        ],
+      },
+      { $set: { movieBaseId } }
+    );
+    matchedArticles += result.modifiedCount;
+  }
+  console.log(`linkPttArticlesForMovieBases: linked ${matchedArticles} articles`);
+  return matchedArticles;
+}
+
+async function upsertMergedMovies(movieBases: MovieBase[], pttArticles: Article[], label: string) {
   const merged = mergeData(movieBases, pttArticles);
-  console.log(`runMerge: ${merged.length} movies`);
+  console.log(`${label}: ${merged.length} movies`);
+
+  if (!merged.length) {
+    return merged;
+  }
 
   const batchSize = 100;
   for (let i = 0; i < merged.length; i += batchSize) {
@@ -21,6 +88,10 @@ export async function runMerge() {
     await bulk.execute();
   }
 
-  console.log('runMerge: done');
+  console.log(`${label}: done`);
   return merged;
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/src/task/pttTask.ts
+++ b/src/task/pttTask.ts
@@ -2,29 +2,56 @@ import { getPttPage, findMovieBaseId } from '../crawler/pttCrawler';
 import { Mongo } from '../data/db';
 import { ObjectId } from 'mongodb';
 import Article from '../models/article';
+import MovieBase from '../models/movieBase';
 import PttPage from '../models/pttPage';
 import { COLLECTIONS } from '../data/collections';
+
+export interface PttUpdateResult {
+  counts: PttCount[];
+  movieBaseIds: string[];
+  articleCount: number;
+}
+
+interface PttCount {
+  _id: string;
+  pttGoodCount: number;
+  pttNormalCount: number;
+  pttBadCount: number;
+}
 
 export async function updatePttArticles(howManyPagePerTime) {
   const range = await getCurrentCrawlRange(howManyPagePerTime);
   const pttPages = await getRangePttPages(range);
-  updateMaxPttIndex(pttPages, range.startPttIndex);
+  await updateMaxPttIndex(pttPages, range.startPttIndex);
   const pttArticles: Article[] = ([] as Article[]).concat(
     ...pttPages.map(({ articles }) => articles)
   );
+  const movieBases = await Mongo.db
+    .collection<MovieBase>(COLLECTIONS.movieBases)
+    .find({
+      chineseTitle: { $exists: true, $ne: null },
+      releaseDate: { $exists: true, $ne: null },
+    })
+    .project({ _id: 1, chineseTitle: 1, releaseDate: 1 })
+    .toArray();
   const enriched = pttArticles.map((article) => ({
     ...article,
-    movieBaseId: findMovieBaseId(article.title ?? '', article.date ?? ''),
+    movieBaseId: findMovieBaseId(article.title ?? '', article.date ?? '', movieBases),
   }));
   await Promise.all(
     enriched.map((article) =>
       Mongo.updateDocument({ url: article.url }, article, COLLECTIONS.pttArticles)
     )
   );
+  const movieBaseIds = [...new Set(enriched.map((article) => article.movieBaseId).filter((id): id is string => Boolean(id)))];
 
-  // Aggregate counts from ALL pttArticles per movieBaseId and persist to DB
-  const countAgg = await Mongo.db.collection(COLLECTIONS.pttArticles).aggregate([
-    { $match: { movieBaseId: { $exists: true, $ne: null } } },
+  if (!movieBaseIds.length) {
+    return { counts: [], movieBaseIds: [], articleCount: enriched.length } satisfies PttUpdateResult;
+  }
+
+  // Aggregate counts only for movies touched by this crawl and persist to DB.
+  const countAgg = await Mongo.db.collection(COLLECTIONS.pttArticles).aggregate<PttCount>([
+    { $match: { movieBaseId: { $in: movieBaseIds } } },
     { $group: {
       _id: '$movieBaseId',
       pttGoodCount: { $sum: { $cond: [{ $or: [
@@ -48,7 +75,7 @@ export async function updatePttArticles(howManyPagePerTime) {
     console.log(`updatePttArticles: wrote counts for ${countAgg.length} movies`);
   }
 
-  return countAgg;
+  return { counts: countAgg, movieBaseIds, articleCount: enriched.length } satisfies PttUpdateResult;
 }
 
 const crawlerStatusFilter = { name: 'crawlerStatus' };
@@ -79,9 +106,9 @@ async function updateMaxPttIndex(pttPages: PttPage[], startPttIndex: number) {
   if (alreadyCrawlTheNewest) {
     const lastCrawlPttIndex =
       maxCrawledPttIndex - 100 > 0 ? maxCrawledPttIndex - 100 : 0;
-    Mongo.updateDocument(crawlerStatusFilter, { lastCrawlPttIndex }, COLLECTIONS.configs);
+    await Mongo.updateDocument(crawlerStatusFilter, { lastCrawlPttIndex }, COLLECTIONS.configs);
   } else {
-    Mongo.updateDocument(
+    await Mongo.updateDocument(
       crawlerStatusFilter,
       {
         maxPttIndex: Math.max(maxCrawledPttIndex, crawlerStatus.maxPttIndex),

--- a/src/test/incrementalMerge.integration.test.ts
+++ b/src/test/incrementalMerge.integration.test.ts
@@ -1,0 +1,131 @@
+import { MongoClient, ObjectId } from 'mongodb';
+import { Mongo } from '../data/db';
+import { COLLECTIONS } from '../data/collections';
+import { linkPttArticlesForMovieBases, runMergeForMovieBaseIds } from '../task/mergeTask';
+import { updatePttArticles } from '../task/pttTask';
+
+vi.mock('../crawler/pttCrawler', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../crawler/pttCrawler')>();
+  return {
+    ...actual,
+    getPttPage: vi.fn(async (index: number) => ({
+      pageIndex: index,
+      url: `https://www.ptt.cc/bbs/movie/index${index}.html`,
+      articles: [
+        { title: '[好雷] 新文章電影', url: `https://example.test/${index}-good`, date: '2026/06/03' },
+        { title: '[閒聊] 不相關文章', url: `https://example.test/${index}-chat`, date: '2026/06/03' },
+      ],
+    })),
+  };
+});
+
+const integrationIt = process.env.INTEGRATION_MONGO_URL ? it : it.skip;
+
+describe('incremental merge integration', () => {
+  let client: MongoClient;
+
+  beforeAll(async () => {
+    if (!process.env.INTEGRATION_MONGO_URL) return;
+    client = new MongoClient(process.env.INTEGRATION_MONGO_URL);
+    await client.connect();
+    Mongo.dbConnection = client;
+    Mongo.db = client.db();
+  });
+
+  afterAll(async () => {
+    if (!client) return;
+    await Mongo.db.dropDatabase();
+    await client.close();
+    Mongo.dbConnection = null;
+    Mongo.db = null;
+  });
+
+  beforeEach(async () => {
+    if (!process.env.INTEGRATION_MONGO_URL) return;
+    await Mongo.db.dropDatabase();
+  });
+
+  integrationIt('links old articles, updates touched PTT counts, and merges only touched movies', async () => {
+    const oldArticleMovieId = new ObjectId();
+    const newArticleMovieId = new ObjectId();
+
+    await Mongo.db.collection(COLLECTIONS.configs).insertOne({
+      name: 'crawlerStatus',
+      lastCrawlPttIndex: 10,
+      maxPttIndex: 10,
+    });
+    await Mongo.db.collection(COLLECTIONS.movieBases).insertMany([
+      {
+        _id: oldArticleMovieId,
+        chineseTitle: '舊文章電影',
+        englishTitle: 'Old Article Movie',
+        releaseDate: '2026-06-01',
+        lineMovieId: 'old-line-id',
+      },
+      {
+        _id: newArticleMovieId,
+        chineseTitle: '新文章電影',
+        englishTitle: 'New Article Movie',
+        releaseDate: '2026-06-01',
+        lineMovieId: 'new-line-id',
+      },
+    ]);
+    await Mongo.db.collection(COLLECTIONS.pttArticles).insertMany([
+      {
+        title: '[好雷] 舊文章電影',
+        url: 'https://example.test/old-good',
+        date: '2026/06/02',
+      },
+      {
+        title: '[好雷] 其他電影',
+        url: 'https://example.test/other-good',
+        date: '2026/06/02',
+      },
+    ]);
+
+    const linked = await linkPttArticlesForMovieBases([
+      {
+        _id: oldArticleMovieId,
+        chineseTitle: '舊文章電影',
+        releaseDate: '2026-06-01',
+      },
+    ]);
+    expect(linked).toBe(1);
+
+    const oldArticle = await Mongo.db.collection(COLLECTIONS.pttArticles).findOne({ url: 'https://example.test/old-good' });
+    const unrelatedArticle = await Mongo.db.collection(COLLECTIONS.pttArticles).findOne({ url: 'https://example.test/other-good' });
+    expect(oldArticle?.movieBaseId).toBe(oldArticleMovieId.toHexString());
+    expect(unrelatedArticle?.movieBaseId).toBeUndefined();
+
+    const oldMerged = await runMergeForMovieBaseIds([oldArticleMovieId.toHexString()]);
+    expect(oldMerged).toHaveLength(1);
+    const oldMergedDoc = await Mongo.db.collection(COLLECTIONS.mergedDatas).findOne({ movieBaseId: oldArticleMovieId.toHexString() });
+    expect(oldMergedDoc?.relatedArticles).toHaveLength(1);
+    expect(await Mongo.db.collection(COLLECTIONS.mergedDatas).findOne({ movieBaseId: newArticleMovieId.toHexString() })).toBeNull();
+
+    const pttUpdate = await updatePttArticles(2);
+    expect(pttUpdate.articleCount).toBe(4);
+    expect(pttUpdate.movieBaseIds).toEqual([newArticleMovieId.toHexString()]);
+    expect(pttUpdate.counts).toEqual([
+      {
+        _id: newArticleMovieId.toHexString(),
+        pttGoodCount: 2,
+        pttNormalCount: 0,
+        pttBadCount: 0,
+      },
+    ]);
+
+    const status = await Mongo.db.collection(COLLECTIONS.configs).findOne({ name: 'crawlerStatus' });
+    expect(status?.lastCrawlPttIndex).toBe(12);
+    expect(status?.maxPttIndex).toBe(12);
+
+    const movieBaseAfterPtt = await Mongo.db.collection(COLLECTIONS.movieBases).findOne({ _id: newArticleMovieId });
+    expect(movieBaseAfterPtt?.pttGoodCount).toBe(2);
+
+    const newMerged = await runMergeForMovieBaseIds(pttUpdate.movieBaseIds);
+    expect(newMerged).toHaveLength(1);
+    const newMergedDoc = await Mongo.db.collection(COLLECTIONS.mergedDatas).findOne({ movieBaseId: newArticleMovieId.toHexString() });
+    expect(newMergedDoc?.relatedArticles).toHaveLength(2);
+    expect(newMergedDoc?.pttGoodCount).toBe(2);
+  });
+});

--- a/src/test/incrementalMerge.test.ts
+++ b/src/test/incrementalMerge.test.ts
@@ -1,0 +1,125 @@
+import { ObjectId } from 'mongodb';
+import { Mongo } from '../data/db';
+import { COLLECTIONS } from '../data/collections';
+import { linkPttArticlesForMovieBases, runMergeForMovieBaseIds } from '../task/mergeTask';
+
+describe('incremental merge task', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('merges only requested movieBaseIds and their linked PTT articles', async () => {
+    const touchedId = new ObjectId();
+    const untouchedId = new ObjectId();
+    const bulkOps: any[] = [];
+    const finds: any[] = [];
+
+    Mongo.db = {
+      collection(name: string) {
+        if (name === COLLECTIONS.movieBases) {
+          return {
+            find(query: any) {
+              finds.push({ collection: name, query });
+              return {
+                toArray: async () => [
+                  { _id: touchedId, chineseTitle: '測試片', releaseDate: '2026-06-01' },
+                ],
+              };
+            },
+          };
+        }
+        if (name === COLLECTIONS.pttArticles) {
+          return {
+            find(query: any, options: any) {
+              finds.push({ collection: name, query, options });
+              return {
+                toArray: async () => [
+                  { title: '[好雷] 測試片', date: '2026/06/02', movieBaseId: touchedId.toHexString() },
+                ],
+              };
+            },
+          };
+        }
+        if (name === COLLECTIONS.mergedDatas) {
+          return {
+            initializeUnorderedBulkOp() {
+              return {
+                find(filter: any) {
+                  return {
+                    upsert() {
+                      return {
+                        updateOne(update: any) {
+                          bulkOps.push({ filter, update });
+                        },
+                      };
+                    },
+                  };
+                },
+                execute: async () => ({}),
+              };
+            },
+          };
+        }
+        throw new Error(`Unexpected collection ${name}`);
+      },
+    } as any;
+
+    const merged = await runMergeForMovieBaseIds([
+      touchedId.toHexString(),
+      touchedId.toHexString(),
+      untouchedId.toHexString(),
+    ]);
+
+    expect(merged).toHaveLength(1);
+    expect(finds).toEqual([
+      {
+        collection: COLLECTIONS.movieBases,
+        query: { _id: { $in: [touchedId, untouchedId] } },
+      },
+      {
+        collection: COLLECTIONS.pttArticles,
+        query: { movieBaseId: { $in: [touchedId.toHexString(), untouchedId.toHexString()] } },
+        options: { projection: { _id: 0 } },
+      },
+    ]);
+    expect(bulkOps).toHaveLength(1);
+    expect(bulkOps[0].filter).toEqual({ movieBaseId: touchedId.toHexString() });
+    expect(bulkOps[0].update.$set.relatedArticles).toHaveLength(1);
+  });
+
+  it('links old unmatched PTT articles for refreshed LINE movies', async () => {
+    const movieId = new ObjectId();
+    const updates: any[] = [];
+    Mongo.db = {
+      collection(name: string) {
+        if (name !== COLLECTIONS.pttArticles) throw new Error(`Unexpected collection ${name}`);
+        return {
+          updateMany: async (query: any, update: any) => {
+            updates.push({ query, update });
+            return { modifiedCount: 2 };
+          },
+        };
+      },
+    } as any;
+
+    const linked = await linkPttArticlesForMovieBases([
+      { _id: movieId, chineseTitle: '測試.片', releaseDate: '2026-06-01' },
+    ]);
+
+    expect(linked).toBe(2);
+    expect(updates).toEqual([
+      {
+        query: {
+          title: { $regex: '測試\\.片' },
+          date: { $gte: '2026/03/01', $lte: '2026/12/01' },
+          $or: [
+            { movieBaseId: { $exists: false } },
+            { movieBaseId: null },
+            { movieBaseId: '' },
+          ],
+        },
+        update: { $set: { movieBaseId: movieId.toHexString() } },
+      },
+    ]);
+  });
+});

--- a/src/test/pttCrawler.test.ts
+++ b/src/test/pttCrawler.test.ts
@@ -1,27 +1,24 @@
 import { findMovieBaseId, getPttPage } from '../crawler/pttCrawler';
-import cacheManager from '../data/cacheManager';
 
 describe('pttCrawler', () => {
   describe('findMovieBaseId', () => {
-    beforeAll(() => {
-      cacheManager.set(cacheManager.All_MOVIES, [
-        {
-          movieBaseId: 'abc123',
-          chineseTitle: '羅根',
-          englishTitle: 'Logan',
-          releaseDate: '2017-02-28',
-        },
-        {
-          movieBaseId: 'def456',
-          chineseTitle: 'chineseTitle',
-          englishTitle: 'englishTitle',
-          releaseDate: '2013-02-28',
-        },
-      ]);
-    });
+    const movieBases = [
+      {
+        _id: { toHexString: () => 'abc123' },
+        chineseTitle: '羅根',
+        englishTitle: 'Logan',
+        releaseDate: '2017-02-28',
+      },
+      {
+        _id: { toHexString: () => 'def456' },
+        chineseTitle: 'chineseTitle',
+        englishTitle: 'englishTitle',
+        releaseDate: '2013-02-28',
+      },
+    ];
 
     it('should find the matching movieBaseId by chineseTitle within the release window', () => {
-      expect(findMovieBaseId('[普雷] 羅根 (原來還蠻血腥的)', '2017/03/14')).toBe('abc123');
+      expect(findMovieBaseId('[普雷] 羅根 (原來還蠻血腥的)', '2017/03/14', movieBases)).toBe('abc123');
     });
   });
 

--- a/src/test/pttTask.test.ts
+++ b/src/test/pttTask.test.ts
@@ -1,0 +1,114 @@
+import { ObjectId } from 'mongodb';
+import { Mongo } from '../data/db';
+import { COLLECTIONS } from '../data/collections';
+
+const ids = vi.hoisted(() => ({
+  touchedMovieBaseId: '64b7f8f2a7e6a6d7f8c9b001',
+}));
+
+vi.mock('../crawler/pttCrawler', () => ({
+  getPttPage: vi.fn(async (index: number) => ({
+    pageIndex: index,
+    url: `https://www.ptt.cc/bbs/movie/index${index}.html`,
+    articles: [
+      { title: '[好雷] 測試片', url: `https://example.test/${index}`, date: '2026/06/02' },
+      { title: '[閒聊] 不相關', url: `https://example.test/${index}-x`, date: '2026/06/02' },
+    ],
+  })),
+  findMovieBaseId: vi.fn((title: string) => title.includes('測試片') ? ids.touchedMovieBaseId : null),
+}));
+
+describe('pttTask incremental update', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns touched movieBaseIds and aggregates counts only for touched movies', async () => {
+    const updateDocuments: any[] = [];
+    const aggregatePipelines: any[] = [];
+    const movieBaseBulkUpdates: any[] = [];
+    const mergedBulkUpdates: any[] = [];
+
+    (Mongo as any).getDocument = vi.fn(async () => ({
+      lastCrawlPttIndex: 10,
+      maxPttIndex: 10,
+    }));
+    (Mongo as any).updateDocument = vi.fn(async (filter: any, value: any, collectionName: string) => {
+      updateDocuments.push({ filter, value, collectionName });
+      return {};
+    });
+    Mongo.db = {
+      collection(name: string) {
+        if (name === COLLECTIONS.movieBases) {
+          return {
+            find() {
+              return {
+                project() {
+                  return {
+                    toArray: async () => [
+                      { _id: new ObjectId(), chineseTitle: '測試片', releaseDate: '2026-06-01' },
+                    ],
+                  };
+                },
+              };
+            },
+            initializeUnorderedBulkOp() {
+              return {
+                find(filter: any) {
+                  return {
+                    updateOne(update: any) {
+                      movieBaseBulkUpdates.push({ filter, update });
+                    },
+                  };
+                },
+                execute: async () => ({}),
+              };
+            },
+          };
+        }
+        if (name === COLLECTIONS.pttArticles) {
+          return {
+            aggregate(pipeline: any[]) {
+              aggregatePipelines.push(pipeline);
+              return {
+                toArray: async () => [
+                  { _id: ids.touchedMovieBaseId, pttGoodCount: 1, pttNormalCount: 0, pttBadCount: 0 },
+                ],
+              };
+            },
+          };
+        }
+        if (name === COLLECTIONS.mergedDatas) {
+          return {
+            initializeUnorderedBulkOp() {
+              return {
+                find(filter: any) {
+                  return {
+                    updateOne(update: any) {
+                      mergedBulkUpdates.push({ filter, update });
+                    },
+                  };
+                },
+                execute: async () => ({}),
+              };
+            },
+          };
+        }
+        throw new Error(`Unexpected collection ${name}`);
+      },
+    } as any;
+
+    const { updatePttArticles } = await import('../task/pttTask');
+    const result = await updatePttArticles(1);
+
+    expect(result).toEqual({
+      counts: [{ _id: ids.touchedMovieBaseId, pttGoodCount: 1, pttNormalCount: 0, pttBadCount: 0 }],
+      movieBaseIds: [ids.touchedMovieBaseId],
+      articleCount: 2,
+    });
+    expect(aggregatePipelines[0][0]).toEqual({ $match: { movieBaseId: { $in: [ids.touchedMovieBaseId] } } });
+    expect(updateDocuments.filter((op) => op.collectionName === COLLECTIONS.pttArticles)).toHaveLength(2);
+    expect(movieBaseBulkUpdates).toHaveLength(1);
+    expect(mergedBulkUpdates).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## What changed

- Keep `All_MOVIES` as the public UI read cache sourced from `mergedDatas`.
- Simplify `cacheManager.init()` so it reuses `refreshMoviesCache()` instead of duplicating that setup.
- Move PTT article movie matching away from `All_MOVIES`; the PTT task now loads candidate `movieBases` directly from Mongo when assigning `movieBaseId`.
- Make `updateLINEMovies()` return persisted `movieBases` documents with `_id` after upsert.
- Add true incremental merge helpers:
  - `runMergeForMovieBaseIds(movieBaseIds)` loads only touched movie bases and their linked PTT articles.
  - `runMergeForMovieBases(movieBases)` delegates by id.
  - `linkPttArticlesForMovieBases(movieBases)` links old unmatched PTT articles for newly/refreshed LINE movies.
- Update the LINE task to link old PTT articles and merge only LINE-touched movies.
- Update the PTT task to aggregate counts and merge only movies touched by newly crawled PTT articles.
- Await PTT crawler status persistence so `lastCrawlPttIndex`/`maxPttIndex` updates are not racing the task response.
- Remove the hard-coded daily `lastCrawlPttIndex = 10900` reset so the PTT crawler can advance naturally.
- Add `tsx` plus `npm run db:merge` for intentional full rebuild maintenance.

## Why

New LINE movies were being written to `movieBases`, but `mergedDatas` and `All_MOVIES` could lag behind. Since PTT matching previously used `All_MOVIES`, crawlers could miss new movies even though the source data existed.

The new flow uses `movieBases` directly for crawler matching, keeps `mergedDatas` as the UI read model, and makes scheduled merges proportional to changed movie ids instead of all history. Full merge remains available as an explicit maintenance command.

The PTT route also had a bootstrap reset that forced every scheduled run back to page `10901`; removing it lets `updateMaxPttIndex()` keep its own progress.

## Tests added

- `incrementalMerge.test.ts` verifies touched-id merge only loads requested movies/linkable PTT articles and links old unmatched PTT articles by escaped title/date window.
- `pttTask.test.ts` verifies PTT crawling returns touched movie ids and aggregates counts only for those ids.
- `incrementalMerge.integration.test.ts` runs against local docker-compose Mongo when `INTEGRATION_MONGO_URL` is set, verifying actual Mongo writes for old-article linking, touched-id merge, PTT count aggregation, status progress, and merged row creation.

## Production verification

Before this incremental implementation, ran a production merge and verified `屍速禁區` exists in `mergedDatas`:

- `movieBaseId`: `6a09f66acb2871934b2eec2f`
- `lineMovieId`: `280217038`
- `lineMovieDbId`: `59749`
- `lineUrlHash`: `Zarp60g`

Also restarted Cloud Run and confirmed the app cache reloaded fresher data.

## Validation

- `npm test` — 10 files passed, 24 tests passed, 5 skipped
- `npm run test:integration:mongo` — passed against docker-compose Mongo
- `npm run build`