### PR TITLE
[codex] Run tests in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
           cache: npm
 
       - run: npm ci
+      - run: npm test
       - run: npm run build
 
   deploy:


### PR DESCRIPTION
## What changed

- Add `npm test` to the GitHub build workflow after `npm ci` and before `npm run build`.

## Why

PR checks were only running the Next.js build. This makes the Vitest suite part of normal CI for pushes and pull requests to `master`.

## Validation

- `npm test` — passed
- `npm run build` — passed