### PR TITLE
[codex] Clamp PTT crawl range to latest page

### DIFF
--- a/src/crawler/pttCrawler.ts
+++ b/src/crawler/pttCrawler.ts
@@ -34,6 +34,28 @@ export async function getPttPage(index: number): Promise<PttPage> {
   };
 }
 
+export async function getLatestPttIndex(): Promise<number> {
+  const response = await fetch('https://www.ptt.cc/bbs/movie/index.html');
+  const html = await response.text();
+  const $ = cheerio.load(html);
+  const previousPageHref = $('.action-bar a.btn.wide')
+    .map((_, el) => ({
+      href: $(el).attr('href'),
+      text: $(el).text(),
+    }))
+    .get()
+    .find(({ href, text }) => text.includes('上頁') && /\/bbs\/movie\/index\d+\.html/.test(href ?? ''))
+    ?.href;
+  const previousPageIndex = previousPageHref?.match(/index(\d+)\.html/)?.[1];
+
+  if (!previousPageIndex) {
+    const serverReturn = $('.bbs-screen.bbs-content').text() || `${response.status} - ${response.statusText}`;
+    throw new Error(`Can not detect latest ptt index, server return:${serverReturn}`);
+  }
+
+  return Number(previousPageIndex) + 1;
+}
+
 export function findMovieBaseId(articleTitle: string, date: string, movieBases: MovieBase[]): string | null {
   const articleDate = moment(date, 'YYYY/MM/DD');
   const matched = movieBases.find((movie) => {

--- a/src/task/pttTask.ts
+++ b/src/task/pttTask.ts
@@ -1,4 +1,4 @@
-import { getPttPage, findMovieBaseId } from '../crawler/pttCrawler';
+import { getPttPage, findMovieBaseId, getLatestPttIndex } from '../crawler/pttCrawler';
 import { Mongo } from '../data/db';
 import { ObjectId } from 'mongodb';
 import Article from '../models/article';
@@ -21,8 +21,14 @@ interface PttCount {
 
 export async function updatePttArticles(howManyPagePerTime) {
   const range = await getCurrentCrawlRange(howManyPagePerTime);
+  if (range.startPttIndex > range.endPttIndex) {
+    await updatePttCrawlerStatus(range.latestPttIndex, range.latestPttIndex);
+    console.log(`new pttPages count:0, lastCrawlPttIndex:${range.latestPttIndex}`);
+    return { counts: [], movieBaseIds: [], articleCount: 0 } satisfies PttUpdateResult;
+  }
+
   const pttPages = await getRangePttPages(range);
-  await updateMaxPttIndex(pttPages, range.startPttIndex);
+  await updateMaxPttIndex(pttPages, range.latestPttIndex);
   const pttArticles: Article[] = ([] as Article[]).concat(
     ...pttPages.map(({ articles }) => articles)
   );
@@ -81,8 +87,10 @@ export async function updatePttArticles(howManyPagePerTime) {
 const crawlerStatusFilter = { name: 'crawlerStatus' };
 async function getCurrentCrawlRange(howManyPagePerTime) {
   const crawlerStatus = await Mongo.getDocument(crawlerStatusFilter, COLLECTIONS.configs);
+  const latestPttIndex = await getLatestPttIndex();
   const startPttIndex = crawlerStatus.lastCrawlPttIndex + 1;
-  return { startPttIndex, endPttIndex: startPttIndex + howManyPagePerTime - 1 };
+  const endPttIndex = Math.min(startPttIndex + howManyPagePerTime - 1, latestPttIndex);
+  return { startPttIndex, endPttIndex, latestPttIndex };
 }
 
 async function getRangePttPages({ startPttIndex, endPttIndex }) {
@@ -98,26 +106,26 @@ async function getRangePttPages({ startPttIndex, endPttIndex }) {
   return pttPages;
 }
 
-async function updateMaxPttIndex(pttPages: PttPage[], startPttIndex: number) {
+async function updateMaxPttIndex(pttPages: PttPage[], latestPttIndex: number) {
   const pttIndexes = pttPages.map(({ pageIndex }) => pageIndex);
-  const crawlerStatus = await Mongo.getDocument(crawlerStatusFilter, COLLECTIONS.configs);
-  const maxCrawledPttIndex = Math.max(...pttIndexes, startPttIndex);
-  const alreadyCrawlTheNewest = maxCrawledPttIndex === startPttIndex;
-  if (alreadyCrawlTheNewest) {
-    const lastCrawlPttIndex =
-      maxCrawledPttIndex - 100 > 0 ? maxCrawledPttIndex - 100 : 0;
-    await Mongo.updateDocument(crawlerStatusFilter, { lastCrawlPttIndex }, COLLECTIONS.configs);
-  } else {
-    await Mongo.updateDocument(
-      crawlerStatusFilter,
-      {
-        maxPttIndex: Math.max(maxCrawledPttIndex, crawlerStatus.maxPttIndex),
-        lastCrawlPttIndex: maxCrawledPttIndex,
-      },
-      COLLECTIONS.configs
-    );
+  if (!pttIndexes.length) {
+    const crawlerStatus = await Mongo.getDocument(crawlerStatusFilter, COLLECTIONS.configs);
+    await updatePttCrawlerStatus(crawlerStatus.lastCrawlPttIndex, latestPttIndex);
+    console.log(`new pttPages count:0, lastCrawlPttIndex:${crawlerStatus.lastCrawlPttIndex}`);
+    return;
   }
+
+  const maxCrawledPttIndex = Math.max(...pttIndexes);
+  await updatePttCrawlerStatus(maxCrawledPttIndex, latestPttIndex);
   console.log(
     `new pttPages count:${pttPages.length}, lastCrawlPttIndex:${maxCrawledPttIndex}`
+  );
+}
+
+async function updatePttCrawlerStatus(lastCrawlPttIndex: number, maxPttIndex: number) {
+  await Mongo.updateDocument(
+    crawlerStatusFilter,
+    { maxPttIndex, lastCrawlPttIndex },
+    COLLECTIONS.configs
   );
 }

--- a/src/test/incrementalMerge.integration.test.ts
+++ b/src/test/incrementalMerge.integration.test.ts
@@ -16,6 +16,7 @@ vi.mock('../crawler/pttCrawler', async (importOriginal) => {
         { title: '[閒聊] 不相關文章', url: `https://example.test/${index}-chat`, date: '2026/06/03' },
       ],
     })),
+    getLatestPttIndex: vi.fn(async () => 12),
   };
 });
 

--- a/src/test/pttCrawler.test.ts
+++ b/src/test/pttCrawler.test.ts
@@ -1,4 +1,4 @@
-import { findMovieBaseId, getPttPage } from '../crawler/pttCrawler';
+import { findMovieBaseId, getLatestPttIndex, getPttPage } from '../crawler/pttCrawler';
 
 describe('pttCrawler', () => {
   describe('findMovieBaseId', () => {
@@ -36,5 +36,27 @@ describe('pttCrawler', () => {
       const pttPage = await getPttPage(4000);
       expect(pttPage.articles.length).toBeGreaterThan(0);
     }, 5000);
+  });
+
+  describe('getLatestPttIndex', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('detects latest index from the previous-page link on PTT latest page', async () => {
+      vi.stubGlobal('fetch', vi.fn(async () => ({
+        text: async () => `
+          <div class="action-bar">
+            <a class="btn wide" href="/bbs/movie/index1.html">最舊</a>
+            <a class="btn wide" href="/bbs/movie/index11002.html">&lsaquo; 上頁</a>
+            <a class="btn wide disabled">下頁 &rsaquo;</a>
+          </div>
+        `,
+        status: 200,
+        statusText: 'OK',
+      })));
+
+      await expect(getLatestPttIndex()).resolves.toBe(11003);
+    });
   });
 });

--- a/src/test/pttTask.test.ts
+++ b/src/test/pttTask.test.ts
@@ -4,6 +4,7 @@ import { COLLECTIONS } from '../data/collections';
 
 const ids = vi.hoisted(() => ({
   touchedMovieBaseId: '64b7f8f2a7e6a6d7f8c9b001',
+  latestPttIndex: 11,
 }));
 
 vi.mock('../crawler/pttCrawler', () => ({
@@ -15,12 +16,14 @@ vi.mock('../crawler/pttCrawler', () => ({
       { title: '[閒聊] 不相關', url: `https://example.test/${index}-x`, date: '2026/06/02' },
     ],
   })),
+  getLatestPttIndex: vi.fn(async () => ids.latestPttIndex),
   findMovieBaseId: vi.fn((title: string) => title.includes('測試片') ? ids.touchedMovieBaseId : null),
 }));
 
 describe('pttTask incremental update', () => {
   afterEach(() => {
-    vi.restoreAllMocks();
+    ids.latestPttIndex = 11;
+    vi.clearAllMocks();
   });
 
   it('returns touched movieBaseIds and aggregates counts only for touched movies', async () => {
@@ -110,5 +113,110 @@ describe('pttTask incremental update', () => {
     expect(updateDocuments.filter((op) => op.collectionName === COLLECTIONS.pttArticles)).toHaveLength(2);
     expect(movieBaseBulkUpdates).toHaveLength(1);
     expect(mergedBulkUpdates).toHaveLength(1);
+  });
+
+  it('clamps the crawl range to the latest PTT page', async () => {
+    ids.latestPttIndex = 11003;
+    const updateDocuments: any[] = [];
+
+    (Mongo as any).getDocument = vi.fn(async () => ({
+      lastCrawlPttIndex: 11002,
+      maxPttIndex: 11005,
+    }));
+    (Mongo as any).updateDocument = vi.fn(async (filter: any, value: any, collectionName: string) => {
+      updateDocuments.push({ filter, value, collectionName });
+      return {};
+    });
+    Mongo.db = {
+      collection(name: string) {
+        if (name === COLLECTIONS.movieBases) {
+          return {
+            find() {
+              return {
+                project() {
+                  return {
+                    toArray: async () => [
+                      { _id: new ObjectId(), chineseTitle: '測試片', releaseDate: '2026-06-01' },
+                    ],
+                  };
+                },
+              };
+            },
+            initializeUnorderedBulkOp() {
+              return {
+                find() {
+                  return { updateOne() {} };
+                },
+                execute: async () => ({}),
+              };
+            },
+          };
+        }
+        if (name === COLLECTIONS.pttArticles) {
+          return {
+            aggregate() {
+              return {
+                toArray: async () => [
+                  { _id: ids.touchedMovieBaseId, pttGoodCount: 1, pttNormalCount: 0, pttBadCount: 0 },
+                ],
+              };
+            },
+          };
+        }
+        if (name === COLLECTIONS.mergedDatas) {
+          return {
+            initializeUnorderedBulkOp() {
+              return {
+                find() {
+                  return { updateOne() {} };
+                },
+                execute: async () => ({}),
+              };
+            },
+          };
+        }
+        throw new Error(`Unexpected collection ${name}`);
+      },
+    } as any;
+
+    const pttCrawler = await import('../crawler/pttCrawler');
+    const { updatePttArticles } = await import('../task/pttTask');
+    await updatePttArticles(5);
+
+    expect(pttCrawler.getPttPage).toHaveBeenCalledTimes(1);
+    expect(pttCrawler.getPttPage).toHaveBeenCalledWith(11003);
+    expect(updateDocuments).toContainEqual({
+      filter: { name: 'crawlerStatus' },
+      value: { maxPttIndex: 11003, lastCrawlPttIndex: 11003 },
+      collectionName: COLLECTIONS.configs,
+    });
+  });
+
+  it('does not crawl or roll back when already at the latest PTT page', async () => {
+    ids.latestPttIndex = 11003;
+    const updateDocuments: any[] = [];
+
+    (Mongo as any).getDocument = vi.fn(async () => ({
+      lastCrawlPttIndex: 11003,
+      maxPttIndex: 11005,
+    }));
+    (Mongo as any).updateDocument = vi.fn(async (filter: any, value: any, collectionName: string) => {
+      updateDocuments.push({ filter, value, collectionName });
+      return {};
+    });
+
+    const pttCrawler = await import('../crawler/pttCrawler');
+    const { updatePttArticles } = await import('../task/pttTask');
+    const result = await updatePttArticles(5);
+
+    expect(result).toEqual({ counts: [], movieBaseIds: [], articleCount: 0 });
+    expect(pttCrawler.getPttPage).not.toHaveBeenCalled();
+    expect(updateDocuments).toEqual([
+      {
+        filter: { name: 'crawlerStatus' },
+        value: { maxPttIndex: 11003, lastCrawlPttIndex: 11003 },
+        collectionName: COLLECTIONS.configs,
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## What changed

- Add `getLatestPttIndex()` to read PTT `index.html` and derive the current latest board page from the `上頁` link.
- Clamp each PTT crawl range to that latest page instead of blindly trying `lastCrawlPttIndex + pageCount`.
- Replace the old "roll back 100 pages" behavior when the crawler reaches the newest page.
- Refresh `crawlerStatus.maxPttIndex` from the observed latest page, so stale values like `11005` can be corrected.

## Why

Production had `maxPttIndex = 11005`, but live PTT currently shows `index11003` as latest while `11004` and `11005` return 404. The old status logic kept `maxPttIndex` sticky forever and could roll `lastCrawlPttIndex` backward when only the latest page was crawlable.

With this change, if `lastCrawlPttIndex = 11002` and live latest is `11003`, the task crawls only `11003`, then stores both `lastCrawlPttIndex` and `maxPttIndex` as `11003`. If there are no new pages, it does no work and does not roll backward.

## Validation

- Live smoke: `getLatestPttIndex()` returns `11003`
- `npm test` — passed
- `npm run test:integration:mongo` — passed
- `npm run build` — passed