### PR TITLE
[codex] Speed up client navigation reuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ npm-debug.log
 
 /.nyc_output
 /coverage
+/playwright-report
+/test-results
 
 # Terraform files
 *.tfstate

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,12 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   output: 'standalone',
+  experimental: {
+    staleTimes: {
+      dynamic: 300,
+      static: 300,
+    },
+  },
   images: {
     remotePatterns: [
       { protocol: 'https', hostname: 'movie.tw.line.me' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react-dom": "^19.0.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@types/cheerio": "^0.22.2",
         "@types/node": "^22.0.0",
         "@types/react": "^19.0.0",
@@ -1583,6 +1584,22 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -2971,6 +2988,53 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.4.31",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "db:merge": "tsx scripts/runMerge.ts",
     "db:rename-movie-bases": "node scripts/renameYahooMoviesCollection.js",
     "test": "vitest run",
+    "test:e2e": "npm run build && playwright test",
     "test:integration:mongo": "INTEGRATION_MONGO_URL=mongodb://localhost:27018/movierater_incremental_integration vitest run src/test/incrementalMerge.integration.test.ts",
     "test:watch": "vitest"
   },
@@ -33,6 +34,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@types/cheerio": "^0.22.2",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './src/e2e',
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  use: {
+    baseURL: 'http://127.0.0.1:3010',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'PORT=3010 npm run start',
+    url: 'http://127.0.0.1:3010',
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/src/components/NavigationLoadingBoundary.tsx
+++ b/src/components/NavigationLoadingBoundary.tsx
@@ -35,15 +35,29 @@ function getPendingNavigation(href: string, currentPathname: string): PendingNav
 export default function NavigationLoadingBoundary({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const [pendingNavigation, setPendingNavigation] = useState<PendingNavigation>(null);
+  const [showPendingNavigation, setShowPendingNavigation] = useState(false);
 
   useEffect(() => {
     setPendingNavigation(null);
+    setShowPendingNavigation(false);
   }, [pathname]);
 
   useEffect(() => {
-    if (!pendingNavigation) return;
-    const timeout = window.setTimeout(() => setPendingNavigation(null), 15000);
-    return () => window.clearTimeout(timeout);
+    if (!pendingNavigation) {
+      setShowPendingNavigation(false);
+      return;
+    }
+
+    const showTimeout = window.setTimeout(() => setShowPendingNavigation(true), 250);
+    const clearTimeout = window.setTimeout(() => {
+      setPendingNavigation(null);
+      setShowPendingNavigation(false);
+    }, 15000);
+
+    return () => {
+      window.clearTimeout(showTimeout);
+      window.clearTimeout(clearTimeout);
+    };
   }, [pendingNavigation]);
 
   useEffect(() => {
@@ -71,10 +85,10 @@ export default function NavigationLoadingBoundary({ children }: { children: Reac
     };
   }, []);
 
-  if (pendingNavigation === 'movie-list') return <MovieListPageSkeleton />;
-  if (pendingNavigation === 'movie') return <MoviePageSkeleton />;
-  if (pendingNavigation === 'theater') return <TheaterPageSkeleton />;
-  if (pendingNavigation === 'theaters') return <TheatersPageSkeleton />;
-  if (pendingNavigation === 'upcoming') return <UpcomingPageSkeleton />;
+  if (showPendingNavigation && pendingNavigation === 'movie-list') return <MovieListPageSkeleton />;
+  if (showPendingNavigation && pendingNavigation === 'movie') return <MoviePageSkeleton />;
+  if (showPendingNavigation && pendingNavigation === 'theater') return <TheaterPageSkeleton />;
+  if (showPendingNavigation && pendingNavigation === 'theaters') return <TheatersPageSkeleton />;
+  if (showPendingNavigation && pendingNavigation === 'upcoming') return <UpcomingPageSkeleton />;
   return children;
 }

--- a/src/e2e/navigation.spec.ts
+++ b/src/e2e/navigation.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test';
+
+test('home movie navigation restores the home list on browser back', async ({ page }) => {
+  await page.goto('/');
+
+  const firstMovie = page.locator('a[href^="/movie/"]').first();
+  await expect(firstMovie).toBeVisible();
+  const firstMovieHref = await firstMovie.getAttribute('href');
+  expect(firstMovieHref).toMatch(/^\/movie\/.+/);
+
+  await firstMovie.click();
+  await expect(page).toHaveURL(/\/movie\/[^/?#]+/);
+  await expect(page.getByRole('heading', { name: '放映時刻' })).toBeVisible();
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page.locator(`a[href="${firstMovieHref}"]`).first()).toBeVisible();
+});


### PR DESCRIPTION
## What changed

- Enable short Next client router cache reuse with `experimental.staleTimes` for dynamic and static page segments.
- Delay the custom navigation skeleton by 250ms so fast cached navigations/back-like transitions keep showing the current page instead of flashing a full-page skeleton.
- Add Playwright (`@playwright/test`) with `npm run test:e2e` and a browser smoke for home -> movie -> browser back.

## Why

This does not look like a hydration mismatch. Production HTML `GET` requests are cached by the Cloudflare worker, but client-side App Router/RSC navigations are `cf-cache-status: DYNAMIC` and go back to Cloud Run. Next 15 also changed page segment client router cache defaults to `staleTime: 0`, so normal client navigations can refetch page payloads more often than expected.

This makes homepage -> movie -> back and movie -> another route -> back feel slower than necessary. A 5 minute client router cache matches the site data cadence while scheduler tasks still revalidate server/edge data.

## Validation

- Production check: normal HTML GET has `x-vary-fix: hit`, RSC navigation request is `cf-cache-status: DYNAMIC`
- `npx playwright install chromium`
- `npm run test:e2e` — passed
- `npm test` — passed
- `npm run build` — passed